### PR TITLE
Issue作業開始スラッシュコマンドを追加

### DIFF
--- a/.claude/commands/start-issue.md
+++ b/.claude/commands/start-issue.md
@@ -1,0 +1,48 @@
+---
+allowed-tools: Bash(gh issue:*), Bash(git checkout:*), Bash(git pull:*), Bash(git branch:*), Bash(git stash:*), AskUserQuestion, EnterPlanMode, WebSearch, WebFetch
+description: Issue作業を開始（ブランチ作成→Planモード）
+argument-hint: [issue-number]
+---
+
+# Issue作業開始コマンド
+
+このコマンドはIssue作業を開始するためのワークフローを実行します。
+
+## リポジトリ情報
+
+!`git remote -v`
+
+## 現在のブランチ
+
+!`git branch --show-current`
+
+## Open Issues一覧
+
+!`gh issue list --state open`
+
+## タスク
+
+以下の手順でIssue作業を開始してください：
+
+### 1. Issue番号の決定
+
+- 引数 `$1` が指定されている場合: Issue #$1 の作業を開始
+- 引数がない場合: 上記のOpen Issues一覧から `AskUserQuestion` ツールを使って作業するIssueを選択させてください
+
+### 2. Issueの詳細確認
+
+選択されたIssue番号で `gh issue view {番号}` を実行し、Issueの内容を確認してください。
+
+### 3. ブランチ作成
+
+以下の手順でブランチを作成してください：
+
+1. ローカルの変更がある場合は `git stash` で退避
+2. `git checkout main && git pull origin main` でmainブランチを最新化
+3. `git checkout -b issue-{番号}` で作業ブランチを作成
+
+ブランチ命名規則: `issue-{Issue番号}`（例: `issue-123`）
+
+### 4. Planモード開始
+
+`EnterPlanMode` ツールを使用してPlanモードに入り、Issueの内容を基に実装計画を立ててください。


### PR DESCRIPTION
## Summary
- `/start-issue` スラッシュコマンドを追加
- 引数でIssue番号を指定、または対話形式でIssueを選択可能
- `issue-{番号}` 形式でブランチを自動作成し、Planモードで作業開始

## Test plan
- [ ] `/start-issue 5` でIssue #5の作業が開始されることを確認
- [ ] `/start-issue` でOpen Issues一覧から選択できることを確認
- [ ] ブランチ名が `issue-{番号}` 形式で作成されることを確認
- [ ] Planモードに移行することを確認

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)