### PR TITLE
GitHub Pagesへのデプロイを追加

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -23,6 +23,7 @@ permissions:
   contents: read
   pages: write
   id-token: write
+  pull-requests: write
 
 jobs:
   build:
@@ -84,6 +85,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- mainブランチへのプッシュ/マージ時にGitHub Pagesへもデプロイするよう修正
- Azure Static Web Appsへのデプロイと並列実行
- PRオープン/更新時はAzure Static Web Appsのみ（プレビュー機能）

## 変更内容
- `permissions`に`pages: write`と`id-token: write`を追加
- `build`ジョブを分離し、artifactをアップロード
- `deploy-azure`ジョブでAzure Static Web Appsへデプロイ
- `deploy-github-pages`ジョブでGitHub Pagesへデプロイ（mainプッシュ/マージ時のみ）

## GitHub Pages設定
- gh cliでGitHub Pagesを有効化済み
- URL: https://nuitsjp.github.io/spec-driven-docs-infra/

## Test plan
- [ ] PRマージ後、GitHub Actionsワークフローが正常に実行されることを確認
- [ ] Azure Static Web Appsへのデプロイが成功することを確認
- [ ] GitHub Pagesへのデプロイが成功することを確認
- [ ] https://nuitsjp.github.io/spec-driven-docs-infra/ でサイトが表示されることを確認

closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)