### PR TITLE
Implement spec-driven documentation infrastructure

### DIFF
--- a/scripts/Setup-Environments.ps1
+++ b/scripts/Setup-Environments.ps1
@@ -56,6 +56,16 @@ if (-not $script:GetLocationInvoker) {
     $script:GetLocationInvoker = { Get-Location }
 }
 
+if (-not $script:GetEnvironmentVariableInvoker) {
+    $script:GetEnvironmentVariableInvoker = {
+        param(
+            [string] $Variable,
+            [string] $Target
+        )
+        [System.Environment]::GetEnvironmentVariable($Variable, $Target)
+    }
+}
+
 function Install-WingetPackage {
     param(
         [Parameter(Mandatory = $true)]
@@ -74,9 +84,9 @@ function Install-WingetPackage {
 }
 
 function Update-Path {
-    $machinePath = [System.Environment]::GetEnvironmentVariable("PATH", "Machine")
-    $userPath = [System.Environment]::GetEnvironmentVariable("PATH", "User")
-    $env:PATH = "$machinePath;$userPath"
+    $machinePath = & $script:GetEnvironmentVariableInvoker -Variable "PATH" -Target "Machine"
+    $userPath = & $script:GetEnvironmentVariableInvoker -Variable "PATH" -Target "User"
+    $env:PATH = [System.Environment]::ExpandEnvironmentVariables("$machinePath;$userPath")
 }
 
 function Install-NpmGlobalPackage {


### PR DESCRIPTION
レジストリから取得したPATH値に含まれる%ProgramFiles%などの未展開の
環境変数を[System.Environment]::ExpandEnvironmentVariables()を使用して 展開するように修正。これにより、Run-AllTests.ps1実行後にgitやghなどの
コマンドが使用できなくなる問題を解決。

Closes #9